### PR TITLE
[py] Update type annotation to include WebElement

### DIFF
--- a/py/selenium/webdriver/support/expected_conditions.py
+++ b/py/selenium/webdriver/support/expected_conditions.py
@@ -485,7 +485,7 @@ def text_to_be_present_in_element_attribute(
     return _predicate
 
 
-def frame_to_be_available_and_switch_to_it(locator: Union[Tuple[str, str], str]) -> Callable[[WebDriver], bool]:
+def frame_to_be_available_and_switch_to_it(locator: Union[Tuple[str, str], str, WebElement]) -> Callable[[WebDriver], bool]:
     """An expectation for checking whether the given frame is available to
     switch to.
 

--- a/py/selenium/webdriver/support/expected_conditions.py
+++ b/py/selenium/webdriver/support/expected_conditions.py
@@ -491,7 +491,7 @@ def frame_to_be_available_and_switch_to_it(locator: Union[Tuple[str, str], str, 
 
     Parameters:
     ----------
-    locator : Union[Tuple[str, str], str]
+    locator: Union[Tuple[str, str], str, WebElement]
         Used to find the frame.
 
     Returns:


### PR DESCRIPTION
fixes: #15334

This adds `WebElement` to the type annotation for the `frame_to_be_available_and_switch_to_it` function in the `expected_conditions` module. The docstring was also updated to reflect this.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

The type annotation was incorrect, since it was missing `WebElement`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
